### PR TITLE
actions to WordCard

### DIFF
--- a/src/app/sectionPage/SectionPage.tsx
+++ b/src/app/sectionPage/SectionPage.tsx
@@ -116,9 +116,9 @@ export default function SectionPage(): JSX.Element {
         className="word-cards-area"
         style={{ backgroundColor: decodeURIComponent(bgColor) }}
       >
-        {words.map((word) => (
-          <WordCard key={word.id} data={word} />
-        ))}
+        {words.map(
+          (word) => !word.optional?.deleted && <WordCard key={word.id} word={word} />
+        )}
       </div>
     </>
   );

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -62,10 +62,13 @@ export const WRONG_REGISTRATION_MESSAGE = 'Ошибка регистрации';
 export const TRY_REGISTRATION_AGAIN_MESSAGE = 'Проверьте правильность введенных данных';
 export const SUCCESSFUL_REGISTRATION_MESSAGE = 'Вы успешно зарегистрированы';
 export const COULD_NOT_GET_WORDS = 'Не удалось получить список слов. Попробуйте снова';
+export const COULD_NOT_UPDATE_WORD = (word: string | undefined) => {
+  return `Не удалось обновить данные слова "${word}"`;
+};
 
-export const WORD_DIFFICULTY = {
-  HARD: 'hard',
-  EASY: 'easy',
+export const WORD_OPTIONAL_MODE = {
+  hard: 'hard',
+  studied: 'studied',
 };
 
 export const VIDEO_URL = 'https://www.youtube.com/watch?v=dQw4w9WgXcQ';

--- a/src/features/hardOrDeletedWordsPage/HardOrDeletedWordsPage.tsx
+++ b/src/features/hardOrDeletedWordsPage/HardOrDeletedWordsPage.tsx
@@ -18,9 +18,26 @@ import Settings from 'features/settings/Settings';
 import WordCard from 'features/wordCard/WordCard';
 import { makeStyles } from '@material-ui/core/styles';
 import AttentionButton from 'app/./attentionButton/AttentionButton';
-import { SPECIAL_WORD_INDICATOR } from '../../constants';
+import { SPECIAL_WORD_INDICATOR, WORD_OPTIONAL_MODE } from '../../constants';
 
 import './HardOrDeletedWordsPage.scss';
+
+const specialWordIndicatorValues = Object.values(SPECIAL_WORD_INDICATOR);
+type SpecialWordIndicatorValues = typeof specialWordIndicatorValues[number];
+const cardVisibilityCondition = (
+  optional: t.IWordOptions | undefined,
+  indicator: SpecialWordIndicatorValues | undefined
+): boolean => {
+  if (
+    (optional?.deleted && indicator === SPECIAL_WORD_INDICATOR.DEL) ||
+    (optional?.mode === WORD_OPTIONAL_MODE.hard &&
+      !optional?.deleted &&
+      indicator === SPECIAL_WORD_INDICATOR.HARD)
+  ) {
+    return true;
+  }
+  return false;
+};
 
 const useStyles = makeStyles((theme) => ({
   sectorTitle: {
@@ -151,9 +168,12 @@ export default function HardOrDeletedWordsPage(): JSX.Element {
         className="word-cards-area"
         style={{ backgroundColor: decodeURIComponent(String(color)) }}
       >
-        {words.map((word) => (
-          <WordCard key={word.id} data={word} />
-        ))}
+        {words.map(
+          (word) =>
+            cardVisibilityCondition(word.optional, indicator) && (
+              <WordCard key={word.id} word={word} />
+            )
+        )}
       </div>
     </>
   );

--- a/src/features/studiedWordsPage/StudiedWordsPage.tsx
+++ b/src/features/studiedWordsPage/StudiedWordsPage.tsx
@@ -105,7 +105,7 @@ export default function StudiedWordsPage(): JSX.Element {
         style={{ backgroundColor: decodeURIComponent(String(color)) }}
       >
         {words.map((word) => (
-          <WordCard key={word.id} data={word} />
+          <WordCard key={word.id} word={word} />
         ))}
       </div>
     </>

--- a/src/features/wordCard/FormattedText.tsx
+++ b/src/features/wordCard/FormattedText.tsx
@@ -1,20 +1,24 @@
 import React from 'react';
+import { withStyles, WithStyles } from '@material-ui/core';
+import styles from './styles';
 
-interface IProps {
+interface IProps extends WithStyles<typeof styles> {
   text: string;
 }
 
-const FormattedText = ({ text }: IProps): JSX.Element => {
+const FormattedText = ({ classes, text }: IProps): JSX.Element => {
   const regexp = new RegExp('(<b>|<i>)(.*)(<[/]b>|<[/]i>)', 'i');
   const divided = text.split(regexp);
 
+  const word = <span className={classes.word}>{divided[2]}</span>;
+
   return (
-    <>
+    <span>
       {divided[0]}
-      {divided[1] === '<b>' ? <b>{divided[2]}</b> : <i>{divided[2]}</i>}
+      {divided[1] === '<b>' ? <b>{word}</b> : <i>{word}</i>}
       {divided[4]}
-    </>
+    </span>
   );
 };
 
-export default FormattedText;
+export default withStyles(styles, { withTheme: true })(FormattedText);

--- a/src/features/wordCard/styles.ts
+++ b/src/features/wordCard/styles.ts
@@ -2,15 +2,13 @@ import { createStyles, Theme } from '@material-ui/core/styles';
 
 const styles = (theme: Theme) =>
   createStyles({
-    outerBox: {
-      margin: theme.spacing(1),
-    },
     root: {
       display: 'flex',
       flexDirection: 'column',
       width: theme.spacing(40),
       margin: theme.spacing(1),
       background: theme.palette.background.default,
+      boxShadow: theme.shadows[2],
     },
     root__complex: {
       background: theme.palette.warning.light,
@@ -23,10 +21,20 @@ const styles = (theme: Theme) =>
     text: {
       userSelect: 'none',
     },
+    word: {
+      color: theme.palette.primary.main,
+      fontWeight: 'bold',
+    },
     button: {},
-    buttonsGroup: {
+    content: {
+      display: 'flex',
+      flexDirection: 'column',
+      height: '100%',
+    },
+    divider: {
       marginTop: 'auto',
     },
+    buttonsGroup: {},
     audioButton: {
       padding: theme.spacing(0),
       marginRight: theme.spacing(1),

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,3 +1,5 @@
+import { WORD_OPTIONAL_MODE } from './constants';
+
 export type SectionPageParams = {
   sector?: string;
   page?: string;
@@ -91,9 +93,11 @@ export interface IUserLogInData {
   password: string;
 }
 
+const wordOptionalModeValues = Object.values(WORD_OPTIONAL_MODE);
+type WordOptionalModeValues = typeof wordOptionalModeValues[number];
 export interface IWordOptions {
-  mode: string; // "studied" - изучаемое, "hard" - трудное
-  deleted: boolean;
+  mode?: WordOptionalModeValues;
+  deleted?: boolean;
 }
 
 export interface IDefiniteWordOptions {
@@ -120,7 +124,7 @@ export interface IWord {
   wordTranslate: string;
   textMeaningTranslate: string;
   textExampleTranslate: string;
-  optional: IWordOptions;
+  optional?: IWordOptions;
   userWord?: IAdditionalUserWordOptions;
 }
 


### PR DESCRIPTION
# WordCard

 - [X] - при нажатии на кнопки "удалить" или "в сложные" карточка передает на бэк данные и обновляет state на фронте. И кнопка 'восстановить' тоже должна работать, но пока проверить это нет возможности (т.к. нет словаря)
 - [X] - страница SectionPage рендерит только карточки, у которых поле deleted !== true
 - [X] - добавлена thunk 'updateWordOptions', которая создает (если в стэйте на фронте у карточки нет поля optional - значит на бэке не создано это слово у пользователя) или обновляет (в стэйте на фронте у карточки есть поле optional - значит на бэке есть это слово у пользователя) на бэке слово пользователя. Данная thunk может быть использована везде, где нужно обновлять/создавать слово у юзера на бэке, т.е. в играх