### PR TITLE
Refactor/word card

### DIFF
--- a/src/constants.ts
+++ b/src/constants.ts
@@ -1,5 +1,4 @@
 export const PAGES_PER_SECTOR = 30;
-export const PAGES_PER_GROUP = 30;
 export const WORDS_PER_PAGE = 20;
 export const WORD_CARD_WIDTH = 320;
 export const WORD_CARD_MARGIN = 16;
@@ -53,11 +52,6 @@ export const ROUTES = {
   statistic: '/statistic',
 };
 
-export const SPECIAL_WORD_INDICATOR = {
-  DEL: 'del',
-  HARD: 'hard',
-};
-
 export const STATISTIC_KEY = 'stats';
 
 export const GAMES = {
@@ -73,6 +67,7 @@ const defaultStats = {
   correctAnswers: 0,
   series: 0,
 };
+
 export const initialStats = [
   {
     ...defaultStats,
@@ -91,6 +86,7 @@ export const initialStats = [
     name: GAMES.ownGame,
   },
 ];
+
 export const GAME_PART_URL_PATH = 'game';
 
 export const requestStatus = {

--- a/src/features/user-words/userWordsSlice.ts
+++ b/src/features/user-words/userWordsSlice.ts
@@ -7,17 +7,12 @@ import {
 import type { AppDispatch, RootState } from 'app/store';
 import { fetchUserData } from 'features/user/utils';
 import { IStatus, IUserWord } from 'types';
-import {
-  PAGES_PER_GROUP,
-  requestMethods,
-  requestStatus,
-  WORDS_PER_PAGE,
-} from '../../constants';
+import { requestMethods, requestStatus, WORDS_PER_PAGE } from '../../constants';
 
 export const name = 'userWords' as const;
 
 const userWordsAdapter = createEntityAdapter<IUserWord>({
-  sortComparer: (a, b) => (a.group - b.group) * PAGES_PER_GROUP + (a.page - b.page),
+  sortComparer: (a, b) => a.wordId.localeCompare(b.wordId),
 });
 
 const initialState: IStatus = {

--- a/src/features/word-card/WordCard.tsx
+++ b/src/features/word-card/WordCard.tsx
@@ -1,5 +1,4 @@
 import {
-  Avatar,
   Card,
   CardActions,
   CardContent,
@@ -10,12 +9,14 @@ import {
   WithStyles,
 } from '@material-ui/core';
 import { withStyles } from '@material-ui/core/styles';
-import BookIcon from '@material-ui/icons/Book';
-import DeleteIcon from '@material-ui/icons/Delete';
-import PlayArrowIcon from '@material-ui/icons/PlayArrow';
-import PriorityHighIcon from '@material-ui/icons/PriorityHigh';
-import RestoreFromTrashIcon from '@material-ui/icons/RestoreFromTrash';
-import StopIcon from '@material-ui/icons/Stop';
+import {
+  Book as BookIcon,
+  Delete as DeleteIcon,
+  PlayArrow as PlayArrowIcon,
+  PriorityHigh as PriorityHighIcon,
+  RestoreFromTrash as RestoreFromTrashIcon,
+  Stop as StopIcon,
+} from '@material-ui/icons';
 import { ToggleButton, ToggleButtonGroup } from '@material-ui/lab';
 import clsx from 'clsx';
 import { useAppDispatch, useAppSelector, useAudio } from 'common/hooks';
@@ -143,24 +144,34 @@ const WordCard = ({ classes, word, userWord }: Props) => {
     <Card className={classes.root}>
       <CardHeader
         action={getActionIcon()}
-        avatar={
-          <Avatar aria-label="priority" className={classes.avatar}>
-            <PriorityHighIcon />
-          </Avatar>
-        }
+        avatar={isDifficult && <PriorityHighIcon />}
         classes={{
           action: classes.action,
-          title: blinkIfPlaying('audio'),
+          avatar: classes.avatar,
         }}
-        subheader={isShowTranslations && word.wordTranslate}
+        disableTypography
+        subheader={
+          <Typography
+            align="center"
+            className={clsx(isDifficult && classes.important)}
+            variant="body1"
+          >
+            {isShowTranslations && word.wordTranslate}
+          </Typography>
+        }
         title={
-          <>
+          <Typography
+            align="center"
+            className={clsx(blinkIfPlaying('audio'), isDifficult && classes.important)}
+            component="h4"
+            variant="h6"
+          >
             <b>{word.word}</b>
             {` ${word.transcription}`}
-          </>
+          </Typography>
         }
       />
-      <LearningProgress value={88} />
+      <LearningProgress wordId={word.id} />
       <CardMedia
         className={classes.media}
         image={`${api}/${word.image}`}

--- a/src/features/word-card/learning-progress/LearningProgress.tsx
+++ b/src/features/word-card/learning-progress/LearningProgress.tsx
@@ -1,22 +1,37 @@
-import { LinearProgress, WithStyles } from '@material-ui/core';
+import { LinearProgress, Tooltip, WithStyles } from '@material-ui/core';
 import { withStyles } from '@material-ui/core/styles';
 import React, { memo } from 'react';
+import { useAppSelector } from '../../../common/hooks';
+import { selectCorrectVsWrongByWordId } from '../../word-statistics/wordStatisticsSlice';
 import styles from './styles';
 
 interface IProps extends WithStyles<typeof styles> {
-  value: number;
+  wordId: string;
 }
-const LearningProgress = ({ classes, value }: IProps) => (
-  <LinearProgress
-    classes={{
-      determinate: classes.determinate,
-      bar: classes.bar,
-      colorPrimary: classes.colorPrimary,
-    }}
-    color="primary"
-    value={value}
-    variant="determinate"
-  />
-);
+const LearningProgress = ({ classes, wordId }: IProps) => {
+  const {
+    correctAnswerTotal: correct,
+    wrongAnswerTotal: wrong,
+  } = useAppSelector((state) => selectCorrectVsWrongByWordId(state, { wordId }));
+  const value = correct + wrong ? Math.round((correct / (correct + wrong)) * 100) : 0;
+  return (
+    <Tooltip
+      aria-label="learning progress"
+      arrow
+      title={correct + wrong ? `${correct} vs ${wrong}` : ''}
+    >
+      <LinearProgress
+        classes={{
+          determinate: classes.determinate,
+          bar: classes.bar,
+          colorPrimary: classes.colorPrimary,
+        }}
+        color="primary"
+        value={value}
+        variant="determinate"
+      />
+    </Tooltip>
+  );
+};
 
 export default withStyles(styles, { withTheme: true })(memo(LearningProgress));

--- a/src/features/word-card/styles.ts
+++ b/src/features/word-card/styles.ts
@@ -1,5 +1,4 @@
-import { red } from '@material-ui/core/colors';
-import { createStyles, Theme } from '@material-ui/core/styles';
+import { createStyles, fade, Theme } from '@material-ui/core/styles';
 import { WORD_CARD_MARGIN, WORD_CARD_WIDTH } from '../../constants';
 
 // "margin: -4px" in GridList component
@@ -32,9 +31,6 @@ const gameCardStyles = (theme: Theme) =>
         marginBottom: theme.spacing(0),
       },
     },
-    avatar: {
-      backgroundColor: red[theme.palette.type === 'light' ? 200 : 700],
-    },
     actionIcon: {
       height: theme.spacing(5),
       width: theme.spacing(5),
@@ -56,6 +52,20 @@ const gameCardStyles = (theme: Theme) =>
       animationDuration: '1500ms',
       animationTimingFunction: 'ease-in-out',
       animationIterationCount: 'infinite',
+    },
+    important: {
+      color: fade(theme.palette.secondary.dark, 0.54),
+      marginLeft: theme.spacing(-5),
+    },
+    avatar: {
+      position: 'relative',
+      left: theme.spacing(-1.5),
+      top: theme.spacing(-3.5),
+      borderRadius: '50%',
+      width: theme.spacing(3),
+      height: theme.spacing(3),
+      backgroundColor: fade(theme.palette.secondary.light, 0.15),
+      color: fade(theme.palette.secondary.dark, 0.54),
     },
   });
 


### PR DESCRIPTION
Убрал `Avatar`, но добавил badge для трудных слов (в левом верхнем углу карточки.

Теперь полоса над фото показывает статистику по слову (если она доступна). Зелёная полоска, показывающая процент правильных ответов. При наведении мыши показывается `XX vs YY``

![Screenshot from 2021-04-12 15-40-46](https://user-images.githubusercontent.com/5857672/114395825-83ea1f80-9ba5-11eb-8f53-7cea3ab192c4.png)
